### PR TITLE
Add CI workflow to check for commonly misspelled words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,9 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check/.codespellrc
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ois,
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+builtin = clear,informal,en-GB_to_en-US
+check-filenames =
+check-hidden =

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,22 @@
+name: Spell Check
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 `portentax8-m4-proxy`
 =====================
+[![Spell Check](https://github.com/arduino/portentax8-m4-proxy/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino/portentax8-m4-proxy/actions/workflows/spell-check.yml)
+
 #### How-to-use 
 * Compile and upload [`PortentaX8_EchoServer`](https://github.com/arduino/ArduinoCore-mbed/blob/main/libraries/RPC/examples/PortentaX8_EchoServer/PortentaX8_EchoServer.ino)
 ```bash

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -216,7 +216,7 @@ func (self *Server) Stop() *Server {
 	return self
 }
 
-// Listenes on the specified transport.  A single server can listen on the
+// Listens on the specified transport.  A single server can listen on the
 // multiple ports.
 func (self *Server) Listen(listener net.Listener) *Server {
 	self.listeners = append(self.listeners, listener)


### PR DESCRIPTION
On every push, pull request, and periodically, use codespell to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the field of . Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.